### PR TITLE
Remove wrapper style attribute so fixed position children don't break

### DIFF
--- a/js/mlpushmenu.js
+++ b/js/mlpushmenu.js
@@ -206,7 +206,7 @@
 			this.level = 0;
 			// remove class mp-pushed from main wrapper
 			classie.remove( this.wrapper, 'mp-pushed' );
-            this.wrapper.removeAttribute( 'style' );
+			this.wrapper.removeAttribute( 'style' );
 			this._toggleLevels();
 			this.open = false;
 		},


### PR DESCRIPTION
If a fixed position element's parent has translate set on it, it no longer position's itself relative to the window.

My fix removes the translate in the resetMenu function so this should reset itself.
