### PR TITLE
add menu vertical scroll

### DIFF
--- a/css/component.css
+++ b/css/component.css
@@ -142,6 +142,7 @@ html, body, .container, .scroller {
 .mp-cover .mp-level.mp-level-open {
 	-webkit-transform: translate3d(0, 0, 0);
 	transform: translate3d(0, 0, 0);
+	overflow-y: auto;
 }
 
 .mp-cover .mp-level.mp-level-open > ul > li > .mp-level:not(.mp-level-open) {


### PR DESCRIPTION
When the menu content exceed the device height the content is getting truncated preventing the user from accessing those options.
Added a scroll so that user can vertically scroll the menu and access those options as well